### PR TITLE
Swagger Modified

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -2,8 +2,8 @@
   "swagger": "2.0",
   "info": {
     "version": "1.0",
-    "title": "WAY_FARER",
-    "description":  "Way-Farer: A transport booking server API",
+    "title": "Way_Farer",
+    "description": "WAY_FARER: A transport booking server",
     "contact": {}
   },
   "host": "way-farer-app1.herokuapp.com",
@@ -132,19 +132,27 @@
         }
       }
     },
-    "/bookings/{booking_id}": {
+    "/bookings/{{booking:id}}": {
       "delete": {
         "description": "TODO: Add Description",
         "summary": "Users can delete their booking",
         "tags": [
           "Bookings"
         ],
-        "operationId": "BookingsByBookingIdDelete",
+        "operationId": "BookingsBookingIdDelete",
         "deprecated": false,
         "produces": [
           "application/json"
         ],
         "parameters": [
+          {
+            "name": "{booking:id}",
+            "in": "path",
+            "required": true,
+            "type": "integer",
+            "format": "int32",
+            "description": ""
+          },
           {
             "name": "Content-Type",
             "in": "header",
@@ -155,13 +163,6 @@
           {
             "name": "token",
             "in": "header",
-            "required": true,
-            "type": "string",
-            "description": ""
-          },
-          {
-            "name": "booking_id",
-            "in": "path",
             "required": true,
             "type": "string",
             "description": ""
@@ -178,7 +179,7 @@
     "/bookings": {
       "get": {
         "description": "TODO: Add Description",
-        "summary": "Admin can view all bookings",
+        "summary": "Admin can view all bookings, while users can see his/her bookings",
         "tags": [
           "Bookings"
         ],


### PR DESCRIPTION
## This pull request fixes the user being both the admin and the user to see bookings, while the Admin can see all bookings, the users can only see his/her bookings.

##Had to re-edit the head-tag of the get booking routes to "Admin can see all bookings, while a user can see his/her booking only.

##These can be tested by going to the booking routes, and test with user and admin details.
##This is seen in the pivotal tracker where it says the users see a simple descriptive form, where he can input his details and use the service 